### PR TITLE
DEV-137: Make build_runner optional

### DIFF
--- a/setup-flutter/action.yml
+++ b/setup-flutter/action.yml
@@ -32,7 +32,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: flutter pub get
     - shell: bash
-      if: ${{ env.RUN_BUILD_RUNNER || 'true' }}
+      if: ${{ env.RUN_BUILD_RUNNER == '' || env.RUN_BUILD_RUNNER == 'true' }}
       working-directory: ${{ inputs.working-directory }}
       run: flutter pub run build_runner build --delete-conflicting-outputs
     - shell: bash -l {0}

--- a/setup-flutter/action.yml
+++ b/setup-flutter/action.yml
@@ -32,7 +32,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: flutter pub get
     - shell: bash
-      if: ${{ ${{ env.RUN_BUILD_RUNNER }} || 'true' }}
+      if: ${{ env.RUN_BUILD_RUNNER || 'true' }}
       working-directory: ${{ inputs.working-directory }}
       run: flutter pub run build_runner build --delete-conflicting-outputs
     - shell: bash -l {0}

--- a/setup-flutter/action.yml
+++ b/setup-flutter/action.yml
@@ -30,7 +30,11 @@ runs:
       run: flutter clean
     - shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
+      run: flutter pub get
+    - shell: bash
+      if: ${{ ${{ env.RUN_BUILD_RUNNER }} || 'true' }}
+      working-directory: ${{ inputs.working-directory }}
+      run: flutter pub run build_runner build --delete-conflicting-outputs
     - shell: bash -l {0}
       if: ${{ inputs.setup-gems == 'true' }}
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
### This adds 'RUN_BUILD_RUNNER' flag to the env file which can be optionally set.

If the flag is **not** set or set to 'true' it will run the `flutter pub run build_runner build --delete-conflicting-outputs` command. It will not run the command if it is set to 'false'.