### PR TITLE
feat: pass ssh-key to actions/checkout when using submodules

### DIFF
--- a/checkout-ssh/action.yml
+++ b/checkout-ssh/action.yml
@@ -17,6 +17,7 @@ runs:
       with:
         lfs: ${{ inputs.git-lfs }}
         submodules: ${{ inputs.git-submodules }}
+        ssh-key: ${{ inputs.git-submodules != 'false' && inputs.ssh-private-key || '' }}
     - uses: webfactory/ssh-agent@v0.6.0
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}


### PR DESCRIPTION
ssh-key is needed to recursively check out submodules, but I'm scared passing it always will break something, so it's passed only with submodules