### PR TITLE
feat: trufflehog scans full history by default

### DIFF
--- a/trufflehog-scan/action.yml
+++ b/trufflehog-scan/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: ''
   base:
-    description: 'Base branch to compare against. Defaults to the PR base or repository default branch.'
+    description: 'Base commit SHA or ref to scan from. Leave empty to scan the full git history.'
     required: false
     default: ''
   exclude-paths:
@@ -27,6 +27,4 @@ runs:
         INPUT_BASE: ${{ inputs.base }}
         INPUT_EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
         INPUT_INCLUDE_PATHS: ${{ inputs.include-paths }}
-        GITHUB_BASE_REF: ${{ github.base_ref }}
-        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: bash "$GITHUB_ACTION_PATH/scripts/trufflehog_scan.sh"

--- a/trufflehog-scan/scripts/trufflehog_scan.sh
+++ b/trufflehog-scan/scripts/trufflehog_scan.sh
@@ -2,24 +2,9 @@
 set -euo pipefail
 
 # ── Resolve base commit ──────────────────────────────────────────────────────
-# Order of precedence:
-#   1. INPUT_BASE if provided and non-zero (workflow caller passed it).
-#   2. origin/$GITHUB_BASE_REF if set (typical pull_request event).
-#   3. HEAD~1 if it exists (push event with at least one parent).
-#   4. Empty — scan full history (first commit on a brand-new branch).
-ZERO_SHA="0000000000000000000000000000000000000000"
+# When INPUT_BASE is provided, scan from that commit to HEAD.
+# Otherwise scan the full git history.
 BASE="${INPUT_BASE:-}"
-if [[ -z "$BASE" || "$BASE" == "$ZERO_SHA" ]]; then
-    if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-        BASE="$(git rev-parse "origin/$GITHUB_BASE_REF")"
-    elif git rev-parse HEAD~1 >/dev/null 2>&1; then
-        BASE="$(git rev-parse HEAD~1)"
-        echo "::notice::No explicit base supplied; scanning since HEAD~1 ($BASE)."
-    else
-        BASE=""
-        echo "::notice::No parent commit reachable; scanning full git history."
-    fi
-fi
 
 HEAD_SHA="$(git rev-parse HEAD)"
 


### PR DESCRIPTION
## Summary
- Removes automatic base-commit detection from `trufflehog_scan.sh` (PR base auto-detect, HEAD~1 push fallback)
- Default behaviour is now **full git history** — no `--since-commit` flag passed unless `base` is explicitly provided
- The `base` input is kept for callers that want to limit the scan to a specific commit range

## Why
TruffleHog should catch secrets committed at any point in the repo's history, not just the most recent push or PR delta. Full-history scanning is fast enough (~10s on a 1300-commit repo) to run on every CI trigger.

## Test plan
- [ ] Verify action runs without a `base` input and scans full history
- [ ] Verify passing an explicit `base` still limits the scan correctly