### PR TITLE
trufflehog-scan: add annotations and output-file inputs

### DIFF
--- a/trufflehog-scan/action.yml
+++ b/trufflehog-scan/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'Path to a file listing paths to include in the scan.'
     required: false
     default: ''
+  annotations:
+    description: 'Emit GitHub annotations for each finding. Set to "false" to suppress annotations and handle them yourself.'
+    required: false
+    default: 'true'
+  output-file:
+    description: 'Path to write raw TruffleHog JSON findings. If set, the findings file is copied here before cleanup so callers can post-process results.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -27,4 +35,6 @@ runs:
         INPUT_BASE: ${{ inputs.base }}
         INPUT_EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
         INPUT_INCLUDE_PATHS: ${{ inputs.include-paths }}
+        INPUT_ANNOTATIONS: ${{ inputs.annotations }}
+        INPUT_OUTPUT_FILE: ${{ inputs.output-file }}
       run: bash "$GITHUB_ACTION_PATH/scripts/trufflehog_scan.sh"

--- a/trufflehog-scan/scripts/trufflehog_scan.sh
+++ b/trufflehog-scan/scripts/trufflehog_scan.sh
@@ -100,7 +100,13 @@ if [[ $SCAN_EXIT -ne 0 ]]; then
     exit "$SCAN_EXIT"
 fi
 
+# ── Copy findings to caller-specified output file (before cleanup) ────────────
+if [[ -n "${INPUT_OUTPUT_FILE:-}" ]]; then
+    cp "$OUTFILE" "$INPUT_OUTPUT_FILE"
+fi
+
 # ── Emit annotations ──────────────────────────────────────────────────────────
+if [[ "${INPUT_ANNOTATIONS:-true}" == "true" ]]; then
 python3 - "$OUTFILE" << 'PYEOF'
 import sys, json
 
@@ -142,3 +148,13 @@ if count > 0:
 else:
     print("No secrets detected.")
 PYEOF
+else
+    # annotations disabled — still exit non-zero if findings exist
+    if [[ -s "$OUTFILE" ]]; then
+        COUNT=$(grep -c . "$OUTFILE" || true)
+        echo "TruffleHog found $COUNT secret(s). Annotations suppressed (annotations=false)."
+        exit 1
+    else
+        echo "No secrets detected."
+    fi
+fi


### PR DESCRIPTION
## Summary

- Adds `annotations` input (default: `'true'`) — set to `'false'` to suppress `::error` annotations and handle them yourself
- Adds `output-file` input (optional) — if set, copies the raw TruffleHog JSON findings to the specified path before cleanup, so callers can post-process results

## Motivation

When using this action in a cross-repo scanning workflow (e.g. scanning all org repos from a governance repo), the generated annotations always link back to the workflow's own repo rather than the scanned repo. By disabling annotations and capturing the raw JSON, the calling workflow can emit its own annotations with correct links to the target repo.

## Backwards compatibility

Both inputs have defaults that preserve existing behaviour exactly. Workflows that don't set these inputs will see no change.

## Test plan

- [ ] Existing call without new inputs — annotations emitted, behaviour unchanged
- [ ] `annotations: 'false'`, no `output-file` — no annotations, exits non-zero on findings
- [ ] `annotations: 'false'`, `output-file: /tmp/findings.json` — no annotations, findings JSON written to specified path