### PR TITLE
feat(trufflehog-scan): skip releases younger than minimum-age-days when auto-resolving version

### DIFF
--- a/trufflehog-scan/action.yml
+++ b/trufflehog-scan/action.yml
@@ -2,9 +2,13 @@ name: 'TruffleHog Scan'
 description: 'Scans for verified secrets using TruffleHog OSS.'
 inputs:
   version:
-    description: 'TruffleHog version to download (e.g. "3.88.1"). Defaults to the latest release.'
+    description: 'TruffleHog version to download (e.g. "3.88.1"). Defaults to the newest release that is at least minimum-age-days old.'
     required: false
     default: ''
+  minimum-age-days:
+    description: 'Minimum age in days a release must be before it is auto-selected. Ignored when version is explicitly set. Default: 3.'
+    required: false
+    default: '3'
   base:
     description: 'Base commit SHA or ref to scan from. Leave empty to scan the full git history.'
     required: false
@@ -32,6 +36,7 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_MIN_AGE_DAYS: ${{ inputs.minimum-age-days }}
         INPUT_BASE: ${{ inputs.base }}
         INPUT_EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
         INPUT_INCLUDE_PATHS: ${{ inputs.include-paths }}

--- a/trufflehog-scan/scripts/trufflehog_scan.sh
+++ b/trufflehog-scan/scripts/trufflehog_scan.sh
@@ -16,21 +16,16 @@ VERSION="${INPUT_VERSION:-}"
 if [[ -z "$VERSION" ]]; then
     MIN_AGE_DAYS="${INPUT_MIN_AGE_DAYS:-3}"
     VERSION=$(curl -sSf "https://api.github.com/repos/trufflesecurity/trufflehog/releases?per_page=30" \
-        | python3 -c "
-import sys, json
-from datetime import datetime, timezone, timedelta
-min_age = int('${MIN_AGE_DAYS}')
-cutoff = datetime.now(timezone.utc) - timedelta(days=min_age)
-for r in json.load(sys.stdin):
-    if r.get('draft') or r.get('prerelease'):
-        continue
-    published = datetime.fromisoformat(r['published_at'].replace('Z', '+00:00'))
-    if published <= cutoff:
-        print(r['tag_name'].lstrip('v'))
-        sys.exit(0)
-print(f'No TruffleHog release is at least {min_age} day(s) old.', file=sys.stderr)
-sys.exit(1)
-")
+        | jq -r --argjson days "$MIN_AGE_DAYS" '
+            map(select(
+                .draft == false and
+                .prerelease == false and
+                (.published_at | fromdateiso8601) <= (now - ($days * 86400))
+            )) | first | .tag_name | ltrimstr("v")')
+    if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+        echo "::error::No TruffleHog release found that is at least ${MIN_AGE_DAYS} day(s) old."
+        exit 1
+    fi
 fi
 
 ARCH=$(uname -m)

--- a/trufflehog-scan/scripts/trufflehog_scan.sh
+++ b/trufflehog-scan/scripts/trufflehog_scan.sh
@@ -14,8 +14,23 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # ── Resolve TruffleHog version ───────────────────────────────────────────────
 VERSION="${INPUT_VERSION:-}"
 if [[ -z "$VERSION" ]]; then
-    VERSION=$(curl -sSf "https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest" \
-        | python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'].lstrip('v'))")
+    MIN_AGE_DAYS="${INPUT_MIN_AGE_DAYS:-3}"
+    VERSION=$(curl -sSf "https://api.github.com/repos/trufflesecurity/trufflehog/releases?per_page=30" \
+        | python3 -c "
+import sys, json
+from datetime import datetime, timezone, timedelta
+min_age = int('${MIN_AGE_DAYS}')
+cutoff = datetime.now(timezone.utc) - timedelta(days=min_age)
+for r in json.load(sys.stdin):
+    if r.get('draft') or r.get('prerelease'):
+        continue
+    published = datetime.fromisoformat(r['published_at'].replace('Z', '+00:00'))
+    if published <= cutoff:
+        print(r['tag_name'].lstrip('v'))
+        sys.exit(0)
+print(f'No TruffleHog release is at least {min_age} day(s) old.', file=sys.stderr)
+sys.exit(1)
+")
 fi
 
 ARCH=$(uname -m)


### PR DESCRIPTION
## Summary

- When no explicit `version` is set, the action now walks the releases list and picks the **newest release that is at least `minimum-age-days` old** (default: 3 days) instead of blindly taking the latest
- Adds a new `minimum-age-days` input (default `'3'`); ignored when `version` is explicitly pinned
- Prevents newly published TruffleHog releases from being picked up immediately, giving time for supply-chain verification

## How it works

The version resolution switches from the `/releases/latest` endpoint to `/releases?per_page=30`, iterates newest-first (skipping drafts and pre-releases), and selects the first entry whose `published_at` is older than the cutoff. Fails loudly if no qualifying release is found.

## Test plan

- [ ] Run without `version` set — confirm a version ≥ 3 days old is selected
- [ ] Set `minimum-age-days: 0` — confirm the very latest release is picked
- [ ] Set `version: 3.88.1` — confirm the age check is bypassed entirely