### PR TITLE
fix(ci): use ubuntu-latest for bats tests (public repo)

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-js-supply-chain:
-    runs-on: [default-k8s-runner]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: bats-core/bats-action@2


### PR DESCRIPTION
## Summary

- Replaces `default-k8s-runner` with `ubuntu-latest` in the `Test actions` workflow
- The self-hosted runner was silently never picking up jobs because this is a public repo — bats tests have no dependency on the custom runner

## Test plan

- [ ] Verify the `Test actions` workflow triggers and passes on this PR