### PR TITLE
fix(js-supply-chain-check): set INPUT_MINIMUM_RELEASE_AGE_MINUTES in unit test setup

### DIFF
--- a/js-supply-chain-check/tests/helpers.bats
+++ b/js-supply-chain-check/tests/helpers.bats
@@ -5,6 +5,7 @@ load "setup.bash"
 setup() {
     _JS_SC_TESTING=1 \
     INPUT_SEARCH_DIRECTORY="${FIXTURES}/pnpm-ok" \
+    INPUT_MINIMUM_RELEASE_AGE_MINUTES="4320" \
         source "$SCRIPT"
     set +e +u +o pipefail
 }

--- a/js-supply-chain-check/tests/parsers.bats
+++ b/js-supply-chain-check/tests/parsers.bats
@@ -5,6 +5,7 @@ load "setup.bash"
 setup() {
     _JS_SC_TESTING=1 \
     INPUT_SEARCH_DIRECTORY="${FIXTURES}/pnpm-ok" \
+    INPUT_MINIMUM_RELEASE_AGE_MINUTES="4320" \
         source "$SCRIPT"
     set +e +u +o pipefail
     D="$BATS_TEST_TMPDIR"


### PR DESCRIPTION
## Summary

- `helpers.bats` and `parsers.bats` source the script directly with `_JS_SC_TESTING=1` but didn't set `INPUT_MINIMUM_RELEASE_AGE_MINUTES`, causing 84 test failures due to `unbound variable` under `set -u`
- Adds `INPUT_MINIMUM_RELEASE_AGE_MINUTES="4320"` to both `setup()` functions, matching the default already used in `run_script()` in `setup.bash`

## Test plan

- [ ] Failures drop from 90 → 6 (the remaining 6 are pre-existing functional failures in `edge_cases.bats`, unrelated to this fix)