### PR TITLE
add node auth token env in vulnerability-and-outdated-packages-report

### DIFF
--- a/web-vulnerability-and-outdated-packages-report/action.yml
+++ b/web-vulnerability-and-outdated-packages-report/action.yml
@@ -32,6 +32,8 @@ runs:
         name: Setup yarn
         run: cd ${{ inputs.working-directory }} && npm install -g yarn
       - shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
         run: |
           project_path=`pwd`/${{ inputs.working-directory }}
           bash generate_reports.sh --project-path=$project_path --reports-path=$project_path/${{ inputs.reports-directory }} --modules=${{ inputs.modules }} $( [[ ${{ inputs.enable-logging }} == true ]] && echo '--enable-logging' || echo '' )


### PR DESCRIPTION
dependency report for web is failing due to the missing `NODE_AUTH_TOKEN` which is required for the internal QB npm packages used in the projects.

The error:

```
yarn install v1.22.22
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
    at /home/runner/_work/_tool/node/24.12.0/x64/lib/node_modules/yarn/lib/cli.js:95453:13
    at String.replace (<anonymous>)
    at envReplace (/home/runner/_work/_tool/node/24.12.0/x64/lib/node_modules/yarn/lib/cli.js:95448:16)
    at NpmRegistry.normalizeConfig (/home/runner/_work/_tool/node/24.12.0/x64/lib/node_modules/yarn/lib/cli.js:31940:69)
    at NpmRegistry.<anonymous> (/home/runner/_work/_tool/node/24.12.0/x64/lib/node_modules/yarn/lib/cli.js:31970:34)
    at Generator.next (<anonymous>)
    at step (/home/runner/_work/_tool/node/24.12.0/x64/lib/node_modules/yarn/lib/cli.js:310:30)
    at /home/runner/_work/_tool/node/24.12.0/x64/lib/node_modules/yarn/lib/cli.js:321:13
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
    at /home/runner/_work/_tool/node/24.12.0/x64/lib/node_modules/yarn/lib/cli.js:95453:13
    at String.replace (<anonymous>)
```
  
More info [here](https://github.com/QuickBirdEng/osteocoach/actions/runs/26815177919/job/79061220087)