### PR TITLE
feat: add trufflehog-merge-excludes action

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "js-supply-chain-check/**"
       - "test-repo/**"
+      - "trufflehog-merge-excludes/**"
 
 jobs:
   test-js-supply-chain:
@@ -14,3 +15,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bats-core/bats-action@2
       - run: bats js-supply-chain-check/tests/
+
+  test-trufflehog-merge-excludes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mikefarah/yq@v4.53.2
+      - uses: bats-core/bats-action@2
+      - run: bats trufflehog-merge-excludes/tests/

--- a/trufflehog-merge-excludes/action.yml
+++ b/trufflehog-merge-excludes/action.yml
@@ -1,0 +1,27 @@
+name: 'TruffleHog Merge Excludes'
+description: 'Merges caller-provided and consumer-side TruffleHog exclude-paths into a single file. Reads .qb/security/trufflehog-ignores.yaml from the checked-out repo.'
+inputs:
+  base-exclude-paths:
+    description: 'Path to an existing exclude-paths file to merge with consumer paths. Optional.'
+    required: false
+    default: ''
+  consumer-file:
+    description: 'Path to the consumer TruffleHog ignore YAML file.'
+    required: false
+    default: '.qb/security/trufflehog-ignores.yaml'
+outputs:
+  file:
+    description: 'Path to the merged exclude-paths file, or empty string if no patterns found.'
+    value: ${{ steps.merge.outputs.file }}
+runs:
+  using: 'composite'
+  steps:
+    - uses: mikefarah/yq@v4.53.2
+
+    - name: Merge exclude paths
+      id: merge
+      shell: bash
+      env:
+        INPUT_BASE_EXCLUDE_PATHS: ${{ inputs.base-exclude-paths }}
+        INPUT_CONSUMER_FILE: ${{ inputs.consumer-file }}
+      run: bash "$GITHUB_ACTION_PATH/scripts/merge_excludes.sh"

--- a/trufflehog-merge-excludes/scripts/merge_excludes.sh
+++ b/trufflehog-merge-excludes/scripts/merge_excludes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_FILE="${INPUT_BASE_EXCLUDE_PATHS:-}"
+CONSUMER_FILE="${INPUT_CONSUMER_FILE:-.qb/security/trufflehog-ignores.yaml}"
+MERGED="${RUNNER_TEMP:-/tmp}/trufflehog-excludes-merged.txt"
+
+CONSUMER_PATHS=""
+if [ -f "$CONSUMER_FILE" ]; then
+  CONSUMER_PATHS=$(yq '.paths[]' "$CONSUMER_FILE" 2>/dev/null || true)
+  ACK_COUNT=$(yq '.acknowledged_findings | length' "$CONSUMER_FILE" 2>/dev/null || echo "0")
+  if [ "${ACK_COUNT:-0}" != "0" ]; then
+    echo "::notice::acknowledged_findings in $CONSUMER_FILE are only applied in the nightly org-wide scan, not in PR scans"
+  fi
+fi
+
+if [ -n "$BASE_FILE" ] && [ -n "$CONSUMER_PATHS" ]; then
+  cat "$BASE_FILE" > "$MERGED"
+  echo "$CONSUMER_PATHS" >> "$MERGED"
+  COUNT=$(wc -l < "$MERGED" | xargs)
+  echo "Merged $COUNT exclude pattern(s) from base file + consumer ignore file"
+  echo "file=$MERGED" >> "$GITHUB_OUTPUT"
+elif [ -n "$CONSUMER_PATHS" ]; then
+  echo "$CONSUMER_PATHS" > "$MERGED"
+  COUNT=$(wc -l < "$MERGED" | xargs)
+  echo "Loaded $COUNT exclude pattern(s) from consumer ignore file"
+  echo "file=$MERGED" >> "$GITHUB_OUTPUT"
+elif [ -n "$BASE_FILE" ]; then
+  echo "Using base exclude-paths file (no consumer ignore file found)"
+  echo "file=$BASE_FILE" >> "$GITHUB_OUTPUT"
+else
+  echo "No TruffleHog exclude paths configured"
+fi

--- a/trufflehog-merge-excludes/tests/fixtures/base-excludes.txt
+++ b/trufflehog-merge-excludes/tests/fixtures/base-excludes.txt
@@ -1,0 +1,2 @@
+legacy/exclude/**
+old-fixtures/*.txt

--- a/trufflehog-merge-excludes/tests/fixtures/consumer-ack-only.yaml
+++ b/trufflehog-merge-excludes/tests/fixtures/consumer-ack-only.yaml
@@ -1,0 +1,2 @@
+acknowledged_findings:
+  - { commit: "abc123", path: some/file.ts }

--- a/trufflehog-merge-excludes/tests/fixtures/consumer-both.yaml
+++ b/trufflehog-merge-excludes/tests/fixtures/consumer-both.yaml
@@ -1,0 +1,4 @@
+paths:
+  - test/fixtures/**
+acknowledged_findings:
+  - { commit: "abc123", path: some/file.ts }

--- a/trufflehog-merge-excludes/tests/fixtures/consumer-empty-paths.yaml
+++ b/trufflehog-merge-excludes/tests/fixtures/consumer-empty-paths.yaml
@@ -1,0 +1,3 @@
+paths: []
+acknowledged_findings:
+  - { commit: "abc123", path: some/file.ts }

--- a/trufflehog-merge-excludes/tests/fixtures/consumer-paths-only.yaml
+++ b/trufflehog-merge-excludes/tests/fixtures/consumer-paths-only.yaml
@@ -1,0 +1,3 @@
+paths:
+  - test/fixtures/**
+  - docs/fake-creds.txt

--- a/trufflehog-merge-excludes/tests/merge_excludes.bats
+++ b/trufflehog-merge-excludes/tests/merge_excludes.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+
+load "setup.bash"
+
+# ── No inputs ─────────────────────────────────────────────────────────────────
+
+@test "no consumer file and no base file: outputs empty file key" {
+    INPUT_CONSUMER_FILE="${FIXTURES}/nonexistent.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ -z "$result" ]
+}
+
+# ── Consumer file only ────────────────────────────────────────────────────────
+
+@test "consumer file with paths: outputs merged file containing those paths" {
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-paths-only.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ -n "$result" ]
+    grep -q "test/fixtures/\*\*" "$result"
+    grep -q "docs/fake-creds.txt" "$result"
+}
+
+@test "consumer file with paths only: output contains exactly those paths" {
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-paths-only.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ "$(grep -c '.' "$result")" -eq 2 ]
+}
+
+@test "consumer file with acknowledged_findings only: outputs empty file key and emits notice" {
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-ack-only.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ -z "$result" ]
+    echo "$output" | grep -q "::notice::"
+}
+
+@test "consumer file with both paths and acknowledged_findings: outputs paths, emits notice for ack findings" {
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-both.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ -n "$result" ]
+    grep -q "test/fixtures/\*\*" "$result"
+    echo "$output" | grep -q "::notice::"
+}
+
+@test "consumer file with empty paths list: outputs empty file key" {
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-empty-paths.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ -z "$result" ]
+}
+
+# ── Base file only ────────────────────────────────────────────────────────────
+
+@test "base file only, no consumer file: passes through base file path unchanged" {
+    INPUT_BASE_EXCLUDE_PATHS="${FIXTURES}/base-excludes.txt" \
+    INPUT_CONSUMER_FILE="${FIXTURES}/nonexistent.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ "$result" = "${FIXTURES}/base-excludes.txt" ]
+}
+
+# ── Both files ────────────────────────────────────────────────────────────────
+
+@test "base file and consumer paths: merged file contains patterns from both" {
+    INPUT_BASE_EXCLUDE_PATHS="${FIXTURES}/base-excludes.txt" \
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-paths-only.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ -n "$result" ]
+    grep -q "legacy/exclude/\*\*" "$result"
+    grep -q "test/fixtures/\*\*" "$result"
+    grep -q "docs/fake-creds.txt" "$result"
+}
+
+@test "base file and consumer paths: merged file has more lines than either source alone" {
+    INPUT_BASE_EXCLUDE_PATHS="${FIXTURES}/base-excludes.txt" \
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-paths-only.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    base_count="$(grep -c '.' "${FIXTURES}/base-excludes.txt")"
+    merged_count="$(grep -c '.' "$result")"
+    [ "$merged_count" -gt "$base_count" ]
+}
+
+@test "base file and consumer file with no paths: passes through base file path" {
+    INPUT_BASE_EXCLUDE_PATHS="${FIXTURES}/base-excludes.txt" \
+    INPUT_CONSUMER_FILE="${FIXTURES}/consumer-ack-only.yaml" \
+    run_merge
+    [ "$status" -eq 0 ]
+    result="$(github_output_value file)"
+    [ "$result" = "${FIXTURES}/base-excludes.txt" ]
+}

--- a/trufflehog-merge-excludes/tests/setup.bash
+++ b/trufflehog-merge-excludes/tests/setup.bash
@@ -1,0 +1,26 @@
+TESTS_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+FIXTURES="${TESTS_DIR}/fixtures"
+SCRIPT="${TESTS_DIR}/../scripts/merge_excludes.sh"
+
+run_merge() {
+    local tmp_output
+    tmp_output="$(mktemp)"
+    run env \
+        RUNNER_TEMP="${BATS_TMPDIR}" \
+        GITHUB_OUTPUT="${tmp_output}" \
+        INPUT_BASE_EXCLUDE_PATHS="${INPUT_BASE_EXCLUDE_PATHS:-}" \
+        INPUT_CONSUMER_FILE="${INPUT_CONSUMER_FILE:-}" \
+        bash "$SCRIPT"
+    # surface the GITHUB_OUTPUT content in $output alongside stdout
+    if [ -s "$tmp_output" ]; then
+        output="${output}"$'\n'"$(cat "$tmp_output")"
+    fi
+    rm -f "$tmp_output"
+}
+
+# Return the value of a key written to GITHUB_OUTPUT by the script.
+# Usage: github_output_value "file"
+github_output_value() {
+    local key="$1"
+    echo "$output" | grep "^${key}=" | tail -1 | cut -d= -f2-
+}


### PR DESCRIPTION
## Summary

- New composite action `trufflehog-merge-excludes` that reads `.qb/security/trufflehog-ignores.yaml` from the checked-out repo and merges its `paths` section with any caller-provided `base-exclude-paths` file
- Handles all edge cases: no file, paths only, `acknowledged_findings` only (emits `::notice::`), both, empty paths list, base-only passthrough
- Adds BATS tests (10 cases) covering all merge scenarios
- Adds the new test job to `.github/workflows/test-actions.yml` with yq setup

## Merge order

This PR must be merged **before** the companion PRs in `workflows` and `github-org-governance`, which both call `QuickBirdEng/actions/trufflehog-merge-excludes@main`.

## Test plan

- [ ] CI BATS tests pass (`test-trufflehog-merge-excludes` job)
- [ ] Run locally: `bats trufflehog-merge-excludes/tests/`