### PR TITLE
Add trufflehog-filter-findings action for PR-scan acknowledged_findings support

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -7,6 +7,7 @@ on:
       - "js-supply-chain-check/**"
       - "test-repo/**"
       - "trufflehog-merge-excludes/**"
+      - "trufflehog-filter-findings/**"
 
 jobs:
   test-js-supply-chain:
@@ -23,3 +24,13 @@ jobs:
       - uses: mikefarah/yq@v4.53.2
       - uses: bats-core/bats-action@2
       - run: bats trufflehog-merge-excludes/tests/
+
+  test-trufflehog-filter-findings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install pytest pyyaml
+      - run: pytest trufflehog-filter-findings/tests/

--- a/trufflehog-filter-findings/action.yml
+++ b/trufflehog-filter-findings/action.yml
@@ -1,0 +1,29 @@
+name: 'TruffleHog Filter Findings'
+description: 'Filters raw TruffleHog output against acknowledged_findings in .qb/security/trufflehog-ignores.yaml and emits annotations for remaining findings.'
+inputs:
+  findings-file:
+    description: 'Path to the raw TruffleHog JSONL output file.'
+    required: true
+  scan-outcome:
+    description: 'Outcome of the trufflehog-scan step (success or failure). Used to distinguish scan errors from clean runs.'
+    required: false
+    default: 'success'
+  fail-on-found:
+    description: 'Exit non-zero if any unacknowledged findings remain after filtering.'
+    required: false
+    default: 'true'
+outputs:
+  count:
+    description: 'Number of unacknowledged findings after filtering.'
+    value: ${{ steps.filter.outputs.count }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Filter and annotate
+      id: filter
+      shell: bash
+      env:
+        INPUT_FINDINGS_FILE: ${{ inputs.findings-file }}
+        INPUT_SCAN_OUTCOME: ${{ inputs.scan-outcome }}
+        INPUT_FAIL_ON_FOUND: ${{ inputs.fail-on-found }}
+      run: python3 "$GITHUB_ACTION_PATH/scripts/filter_findings.py"

--- a/trufflehog-filter-findings/scripts/filter_findings.py
+++ b/trufflehog-filter-findings/scripts/filter_findings.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Filters raw TruffleHog JSONL output against acknowledged_findings from
+.qb/security/trufflehog-ignores.yaml, emits GitHub annotations, and
+exits non-zero when unacknowledged findings remain and fail-on-found is true.
+
+Environment variables (set by action.yml):
+  INPUT_FINDINGS_FILE  - path to raw TruffleHog JSONL output
+  INPUT_SCAN_OUTCOME   - 'success' or 'failure' (from the scan step)
+  INPUT_FAIL_ON_FOUND  - 'true' or 'false'
+"""
+import json
+import os
+import sys
+
+
+def load_acknowledged_findings():
+    """Return set of (commit, path) tuples from .qb/security/trufflehog-ignores.yaml."""
+    findings = set()
+    try:
+        import yaml
+        workspace = os.environ.get('GITHUB_WORKSPACE', '')
+        consumer_file = os.path.join(workspace, '.qb/security/trufflehog-ignores.yaml')
+        with open(consumer_file) as f:
+            data = yaml.safe_load(f) or {}
+        for af in (data.get('acknowledged_findings') or []):
+            commit = af.get('commit')
+            path = af.get('path')
+            if commit is not None and path is not None:
+                findings.add((str(commit), path))
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        print(f"Warning: failed to read .qb/security/trufflehog-ignores.yaml: {e}")
+    return findings
+
+
+def find_git_metadata(node):
+    if isinstance(node, dict):
+        if 'file' in node or 'File' in node:
+            return node
+        for v in node.values():
+            r = find_git_metadata(v)
+            if r:
+                return r
+    return {}
+
+
+def _set_output(name, value):
+    output_file = os.environ.get('GITHUB_OUTPUT', '')
+    if output_file:
+        with open(output_file, 'a') as f:
+            f.write(f'{name}={value}\n')
+
+
+def main():
+    findings_file = os.environ.get('INPUT_FINDINGS_FILE', '')
+    scan_outcome = os.environ.get('INPUT_SCAN_OUTCOME', 'success')
+    fail_on_found = os.environ.get('INPUT_FAIL_ON_FOUND', 'true').lower() == 'true'
+
+    if not findings_file or not os.path.exists(findings_file):
+        if scan_outcome == 'failure':
+            print('::error::TruffleHog scan failed without producing findings output. Check the scan step logs.')
+            sys.exit(1)
+        _set_output('count', '0')
+        sys.exit(0)
+
+    seen = set()
+    records = []
+    with open(findings_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+                git = find_git_metadata(d.get('SourceMetadata', {}))
+                path = git.get('file', git.get('File', ''))
+                lineno = git.get('line', git.get('Line', 1)) or 1
+                commit = git.get('commit', git.get('Commit', ''))
+                detector = d.get('DetectorName', 'Unknown')
+                key = (path, lineno, detector)
+                if path and key not in seen:
+                    seen.add(key)
+                    records.append({'path': path, 'line': lineno, 'commit': commit, 'detector': detector})
+            except Exception:
+                pass
+
+    acknowledged = load_acknowledged_findings()
+    if acknowledged:
+        before = len(records)
+        records = [r for r in records if (str(r['commit']), r['path']) not in acknowledged]
+        suppressed = before - len(records)
+        if suppressed:
+            print(f"Suppressed {suppressed} acknowledged finding(s) based on .qb/security/trufflehog-ignores.yaml")
+
+    _set_output('count', str(len(records)))
+
+    for r in records:
+        print(f"::error file={r['path']},line={r['line']}::TruffleHog [{r['detector']}]: verified secret detected (commit {r['commit']})")
+
+    sys.exit(1 if records and fail_on_found else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/trufflehog-filter-findings/tests/test_filter_findings.py
+++ b/trufflehog-filter-findings/tests/test_filter_findings.py
@@ -1,0 +1,247 @@
+"""Tests for filter_findings.py."""
+import json
+import os
+import sys
+import tempfile
+import textwrap
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'filter_findings.py')
+
+
+def _load_module(consumer_yaml=None, workspace=None):
+    """Load filter_findings module with optional .qb/security/trufflehog-ignores.yaml content."""
+    tmpdir = workspace or tempfile.mkdtemp()
+
+    if consumer_yaml is not None:
+        qb_dir = os.path.join(tmpdir, '.qb', 'security')
+        os.makedirs(qb_dir, exist_ok=True)
+        with open(os.path.join(qb_dir, 'trufflehog-ignores.yaml'), 'w') as f:
+            f.write(textwrap.dedent(consumer_yaml))
+
+    os.environ['GITHUB_WORKSPACE'] = tmpdir
+
+    with open(SCRIPT) as f:
+        source = f.read()
+
+    ns = {'os': os, 'sys': sys, 'json': json, '__name__': '__not_main__'}
+    exec(compile(source, SCRIPT, 'exec'), ns)
+    return ns, tmpdir
+
+
+def _make_finding(path, line, commit, detector='GitHub'):
+    return json.dumps({
+        'DetectorName': detector,
+        'SourceMetadata': {
+            'Data': {
+                'Git': {
+                    'file': path,
+                    'line': line,
+                    'commit': commit,
+                }
+            }
+        }
+    })
+
+
+def _write_findings(tmpdir, findings):
+    p = os.path.join(str(tmpdir), 'findings.json')
+    with open(p, 'w') as f:
+        for finding in findings:
+            f.write(finding + '\n')
+    return p
+
+
+def _run_main(ns):
+    try:
+        ns['main']()
+        return 0
+    except SystemExit as e:
+        return int(e.code) if e.code is not None else 0
+
+
+# ── load_acknowledged_findings ────────────────────────────────────────────────
+
+def test_load_acknowledged_findings_from_consumer_file():
+    ns, _ = _load_module(consumer_yaml="""
+        acknowledged_findings:
+          - { commit: "abc123", path: src/secrets.ts }
+    """)
+    result = ns['load_acknowledged_findings']()
+    assert result == {('abc123', 'src/secrets.ts')}
+
+
+def test_load_acknowledged_findings_absent_file_returns_empty():
+    ns, _ = _load_module()
+    result = ns['load_acknowledged_findings']()
+    assert result == set()
+
+
+def test_load_acknowledged_findings_missing_commit_or_path_skipped():
+    ns, _ = _load_module(consumer_yaml="""
+        acknowledged_findings:
+          - { commit: "abc123" }
+          - { path: "some/file.ts" }
+          - { commit: "def456", path: "valid.ts" }
+    """)
+    result = ns['load_acknowledged_findings']()
+    assert result == {('def456', 'valid.ts')}
+
+
+def test_load_acknowledged_findings_commit_coerced_to_string():
+    ns, _ = _load_module(consumer_yaml="""
+        acknowledged_findings:
+          - { commit: 1234567890, path: src/file.ts }
+    """)
+    result = ns['load_acknowledged_findings']()
+    assert ('1234567890', 'src/file.ts') in result
+
+
+# ── find_git_metadata ─────────────────────────────────────────────────────────
+
+def test_find_git_metadata_extracts_nested_file_key():
+    ns, _ = _load_module()
+    meta = {'Data': {'Git': {'file': 'src/main.ts', 'line': 42, 'commit': 'abc123'}}}
+    result = ns['find_git_metadata'](meta)
+    assert result['file'] == 'src/main.ts'
+
+
+def test_find_git_metadata_returns_empty_dict_for_no_match():
+    ns, _ = _load_module()
+    result = ns['find_git_metadata']({'a': {'b': {'c': 'x'}}})
+    assert result == {}
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def test_main_no_findings_file_scan_success_exits_zero(tmp_path):
+    ns, _ = _load_module()
+    os.environ['INPUT_FINDINGS_FILE'] = str(tmp_path / 'nonexistent.json')
+    os.environ['INPUT_SCAN_OUTCOME'] = 'success'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'true'
+    os.environ['GITHUB_OUTPUT'] = str(tmp_path / 'output')
+    assert _run_main(ns) == 0
+
+
+def test_main_no_findings_file_scan_failure_exits_nonzero(tmp_path, capsys):
+    ns, _ = _load_module()
+    os.environ['INPUT_FINDINGS_FILE'] = str(tmp_path / 'nonexistent.json')
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'true'
+    os.environ.pop('GITHUB_OUTPUT', None)
+    assert _run_main(ns) == 1
+    assert '::error::' in capsys.readouterr().out
+
+
+def test_main_empty_findings_exits_zero(tmp_path):
+    findings_file = _write_findings(tmp_path, [])
+    ns, _ = _load_module()
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'success'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'true'
+    os.environ['GITHUB_OUTPUT'] = str(tmp_path / 'output')
+    assert _run_main(ns) == 0
+
+
+def test_main_unacknowledged_finding_emits_annotation_and_exits_one(tmp_path, capsys):
+    findings_file = _write_findings(tmp_path, [
+        _make_finding('src/secret.ts', 10, 'deadbeef'),
+    ])
+    ns, _ = _load_module()
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'true'
+    os.environ['GITHUB_OUTPUT'] = str(tmp_path / 'output')
+    assert _run_main(ns) == 1
+    assert '::error file=src/secret.ts,line=10::' in capsys.readouterr().out
+
+
+def test_main_acknowledged_finding_is_suppressed(tmp_path, capsys):
+    findings_file = _write_findings(tmp_path, [
+        _make_finding('src/secret.ts', 10, 'deadbeef'),
+    ])
+    ns, _ = _load_module(consumer_yaml="""
+        acknowledged_findings:
+          - { commit: "deadbeef", path: src/secret.ts }
+    """)
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'true'
+    os.environ['GITHUB_OUTPUT'] = str(tmp_path / 'output')
+    assert _run_main(ns) == 0
+    out = capsys.readouterr().out
+    assert '::error' not in out
+    assert 'Suppressed 1' in out
+
+
+def test_main_same_commit_different_path_not_suppressed(tmp_path, capsys):
+    findings_file = _write_findings(tmp_path, [
+        _make_finding('src/other.ts', 5, 'deadbeef'),
+    ])
+    ns, _ = _load_module(consumer_yaml="""
+        acknowledged_findings:
+          - { commit: "deadbeef", path: src/secret.ts }
+    """)
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'true'
+    os.environ['GITHUB_OUTPUT'] = str(tmp_path / 'output')
+    assert _run_main(ns) == 1
+    assert '::error file=src/other.ts' in capsys.readouterr().out
+
+
+def test_main_same_path_different_commit_not_suppressed(tmp_path):
+    findings_file = _write_findings(tmp_path, [
+        _make_finding('src/secret.ts', 10, 'cafebabe'),
+    ])
+    ns, _ = _load_module(consumer_yaml="""
+        acknowledged_findings:
+          - { commit: "deadbeef", path: src/secret.ts }
+    """)
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'true'
+    os.environ['GITHUB_OUTPUT'] = str(tmp_path / 'output')
+    assert _run_main(ns) == 1
+
+
+def test_main_fail_on_found_false_exits_zero_despite_findings(tmp_path):
+    findings_file = _write_findings(tmp_path, [
+        _make_finding('src/secret.ts', 10, 'deadbeef'),
+    ])
+    ns, _ = _load_module()
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'false'
+    os.environ['GITHUB_OUTPUT'] = str(tmp_path / 'output')
+    assert _run_main(ns) == 0
+
+
+def test_main_count_output_written(tmp_path):
+    findings_file = _write_findings(tmp_path, [
+        _make_finding('src/secret.ts', 10, 'deadbeef'),
+        _make_finding('src/other.ts', 5, 'cafebabe'),
+    ])
+    output_file = str(tmp_path / 'output')
+    ns, _ = _load_module()
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'false'
+    os.environ['GITHUB_OUTPUT'] = output_file
+    _run_main(ns)
+    with open(output_file) as f:
+        assert 'count=2' in f.read()
+
+
+def test_main_duplicate_findings_deduplicated(tmp_path):
+    finding = _make_finding('src/secret.ts', 10, 'deadbeef')
+    findings_file = _write_findings(tmp_path, [finding, finding])
+    output_file = str(tmp_path / 'output')
+    ns, _ = _load_module()
+    os.environ['INPUT_FINDINGS_FILE'] = findings_file
+    os.environ['INPUT_SCAN_OUTCOME'] = 'failure'
+    os.environ['INPUT_FAIL_ON_FOUND'] = 'false'
+    os.environ['GITHUB_OUTPUT'] = output_file
+    _run_main(ns)
+    with open(output_file) as f:
+        assert 'count=1' in f.read()

--- a/trufflehog-merge-excludes/scripts/merge_excludes.sh
+++ b/trufflehog-merge-excludes/scripts/merge_excludes.sh
@@ -8,10 +8,6 @@ MERGED="${RUNNER_TEMP:-/tmp}/trufflehog-excludes-merged.txt"
 CONSUMER_PATHS=""
 if [ -f "$CONSUMER_FILE" ]; then
   CONSUMER_PATHS=$(yq '.paths[]' "$CONSUMER_FILE" 2>/dev/null || true)
-  ACK_COUNT=$(yq '.acknowledged_findings | length' "$CONSUMER_FILE" 2>/dev/null || echo "0")
-  if [ "${ACK_COUNT:-0}" != "0" ]; then
-    echo "::notice::acknowledged_findings in $CONSUMER_FILE are only applied in the nightly org-wide scan, not in PR scans"
-  fi
 fi
 
 if [ -n "$BASE_FILE" ] && [ -n "$CONSUMER_PATHS" ]; then

--- a/trufflehog-merge-excludes/tests/merge_excludes.bats
+++ b/trufflehog-merge-excludes/tests/merge_excludes.bats
@@ -32,23 +32,21 @@ load "setup.bash"
     [ "$(grep -c '.' "$result")" -eq 2 ]
 }
 
-@test "consumer file with acknowledged_findings only: outputs empty file key and emits notice" {
+@test "consumer file with acknowledged_findings only: outputs empty file key" {
     INPUT_CONSUMER_FILE="${FIXTURES}/consumer-ack-only.yaml" \
     run_merge
     [ "$status" -eq 0 ]
     result="$(github_output_value file)"
     [ -z "$result" ]
-    echo "$output" | grep -q "::notice::"
 }
 
-@test "consumer file with both paths and acknowledged_findings: outputs paths, emits notice for ack findings" {
+@test "consumer file with both paths and acknowledged_findings: outputs paths" {
     INPUT_CONSUMER_FILE="${FIXTURES}/consumer-both.yaml" \
     run_merge
     [ "$status" -eq 0 ]
     result="$(github_output_value file)"
     [ -n "$result" ]
     grep -q "test/fixtures/\*\*" "$result"
-    echo "$output" | grep -q "::notice::"
 }
 
 @test "consumer file with empty paths list: outputs empty file key" {


### PR DESCRIPTION
## Summary

- Adds new `trufflehog-filter-findings` composite action that reads `.qb/security/trufflehog-ignores.yaml` from the consumer repo, filters raw TruffleHog JSONL output against `acknowledged_findings`, and emits inline PR annotations for remaining findings
- Removes the stale `::notice::` from `trufflehog-merge-excludes` that said `acknowledged_findings` are not applied in PR scans (they now are)
- Updates `test-actions.yml` to run pytest for the new action

## Test plan

- [ ] CI runs `pytest trufflehog-filter-findings/tests/` green
- [ ] CI runs updated BATS tests for `trufflehog-merge-excludes` green (notice checks removed)